### PR TITLE
취업공고 이슈 관련에 대한 토론 영상(개발바닥)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [Go 언어](#Go-언어)
 - [스타트업](#스타트업)
 - [Electron](#Electron)
+- [etc](#etc)
 
 ## 유튜브 영상
 
@@ -57,3 +58,7 @@
 ### Electron
 
 - [앱 만들고 싶다면 이것 부터 하세요. 10분컷.](https://youtu.be/6Ep8ot0ABH0) / 2022.03.27
+
+### etc
+
+- [XX코딩 교육기관 출신 우대, 취업시장에 새로운 허들이 될까?](https://youtu.be/qdX47ySzzb0) / 22.03.29


### PR DESCRIPTION
OO기업에서 실수로 취업공고 필수자격으로 '부트캠프 수료자'가 작성되어, 이슈가 되었던 사건에 대한 토론 내용입니다.